### PR TITLE
Moving the download button logic out of the activity

### DIFF
--- a/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/CheeseyDownloaderFeature.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/CheeseyDownloaderFeature.kt
@@ -1,0 +1,65 @@
+package io.mercury.coroutinesandbox.view.downloader
+
+import dagger.hilt.android.scopes.ActivityScoped
+import io.mercury.coroutinesandbox.interactors.DownloadMovie
+import io.mercury.coroutinesandbox.view.downloader.State.DownloadsAvailable
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.*
+import javax.inject.Inject
+
+@ActivityScoped
+class CheeseyDownloaderFeature @Inject constructor(
+    private val coroutineScope: CoroutineScope,
+    private val backgroundDispatcher: CoroutineDispatcher,
+    val downloadMovie: DownloadMovie
+) {
+    private val statePublisher =
+        MutableStateFlow<State>(DownloadsAvailable.from("tt0068646", "tt0111161", "tt0108052"))
+    val state get() = statePublisher.asStateFlow()
+
+    fun download() {
+        state.value.also { currentState ->
+            if (currentState is DownloadsAvailable) {
+                val id = currentState.downloadables.pop()
+                coroutineScope.launch(backgroundDispatcher) {
+                    downloadMovie(id)
+                }
+
+                coroutineScope.launch {
+                    statePublisher.emit(State.from(currentState))
+                }
+            }
+        }
+
+    }
+}
+
+sealed class State {
+    class DownloadsAvailable(val downloadables: Stack<String>) : State() {
+        companion object {
+            fun from(vararg ids: String): DownloadsAvailable {
+                return DownloadsAvailable(Stack<String>().also { stack ->
+                    ids.forEach { id ->
+                        stack.push(id)
+                    }
+                })
+            }
+        }
+    }
+
+    object DownloadsUnavailable : State()
+
+    companion object {
+        fun from(state: State): State {
+            return if (state is DownloadsAvailable && state.downloadables.isNotEmpty()) {
+                DownloadsAvailable(state.downloadables)
+            } else {
+                DownloadsUnavailable
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/DownloadListActivity.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/DownloadListActivity.kt
@@ -106,7 +106,7 @@ class DownloadListActivity : ComponentActivity() {
                 val downloaderState = remember { downloaderFeature.state }.collectAsState()
                 val remainingDownloads = downloaderState.value.let { state ->
                     if (state is DownloadsAvailable) {
-                        state.downloadables.size
+                        state.downloadables.size - state.downloaded.size
                     } else {
                         0
                     }

--- a/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/DownloadListViewModel.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/DownloadListViewModel.kt
@@ -3,14 +3,18 @@ package io.mercury.coroutinesandbox.view.downloader
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.mercury.coroutinesandbox.interactors.DownloadMovie
 import io.mercury.coroutinesandbox.interactors.GetDownloadedMovies
 import io.mercury.coroutinesandbox.interactors.GetInProgressDownloads
+import kotlinx.coroutines.Dispatchers
 import javax.inject.Inject
 
 @HiltViewModel
 class DownloadListViewModel @Inject constructor(
     getDownloadedMovies: GetDownloadedMovies,
-    getInProgressDownloads: GetInProgressDownloads
+    getInProgressDownloads: GetInProgressDownloads,
+    downloadMovie: DownloadMovie
 ) : ViewModel() {
     val feature = DownloadListFeature(viewModelScope, getInProgressDownloads, getDownloadedMovies)
+    val downloaderFeature = CheeseyDownloaderFeature(viewModelScope, Dispatchers.IO, downloadMovie)
 }


### PR DESCRIPTION
This introduces the idea of having multiple features in an Android ViewModel. This highlights the difference between what a ViewModel is in MVVM vs Android's ViewModel. I never liked that Android named that class "ViewModel" since the real functionality of it is to just have a place to maintain objects that span the lifecycle of the different activity/fragment instances for what we consider one view of them. IOW: It is primarily a way to keep things around during rotation.

The other branch (https://github.com/kmerrell42/android-sandbox/tree/independent-components) already has the concept of multiple features per screen, they are just nested in the composables (for better or worse), so this doesn't really cross any lines in that regard.

Unlike the independent-components, this feature isn't really meant to be shared as a UI object, hence the different treatment.