### PR TITLE
Adding cancel option. Handling concurrency inside the manager

### DIFF
--- a/app/src/main/java/io/mercury/coroutinesandbox/di/SingletonModule.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/di/SingletonModule.kt
@@ -11,14 +11,40 @@ import io.mercury.coroutinesandbox.repos.FavoriteMovieIdsStore
 import io.mercury.coroutinesandbox.repos.FavoriteMovieIdsStoreInMemory
 import io.mercury.coroutinesandbox.repos.MoviesStoreImpl
 import io.mercury.domain.repos.MoviesStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 
 @Module
 @InstallIn(SingletonComponent::class)
 object SingletonModule {
+
+    @Qualifier
+    annotation class ApplicationCoroutineScope
+
+    @Provides
+    @Singleton
+    @ApplicationCoroutineScope
+    fun providesApplicationScope(): CoroutineScope {
+        return MainScope()
+    }
+
+    @Qualifier
+    annotation class BackgroundDispatcher
+
+    @Provides
+    @Singleton
+    @BackgroundDispatcher
+    fun providesBackgroundDispatcher(): CoroutineDispatcher {
+        return Dispatchers.IO
+    }
+
     @Provides
     @Singleton
     fun providesRetrofit(): Retrofit {

--- a/app/src/main/java/io/mercury/coroutinesandbox/interactors/CancelMovieDownload.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/interactors/CancelMovieDownload.kt
@@ -5,8 +5,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class DownloadMovie @Inject constructor(private val downloadManager: MovieDownloadManager) {
+class CancelMovieDownload @Inject constructor(private val movieDownloadManager: MovieDownloadManager) {
     operator fun invoke(id: String) {
-        downloadManager.download(id)
+        movieDownloadManager.cancelDownload(id)
     }
 }

--- a/app/src/main/java/io/mercury/coroutinesandbox/interactors/GetDownloadedStatuses.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/interactors/GetDownloadedStatuses.kt
@@ -16,7 +16,7 @@ class GetDownloadedStatuses @Inject constructor(
     private val downloadManager: MovieDownloadManager,
 ) {
     operator fun invoke(): Flow<Map<String, DownloadState>> {
-        return downloadManager.downloadJobs
+        return downloadManager.downloadStatuses
             .combine(flow { emit(downloadedMovieStore.getIds()) }) { inprogress, downloaded ->
                 HashMap<String, DownloadState>()
                     .also { stateMap ->
@@ -25,7 +25,7 @@ class GetDownloadedStatuses @Inject constructor(
                         }
 
                         stateMap.putAll(inprogress.mapValues { entry ->
-                            Downloading(entry.value.percent)
+                            Downloading(entry.value)
                         })
 
                     }

--- a/app/src/main/java/io/mercury/coroutinesandbox/interactors/GetInProgressDownloads.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/interactors/GetInProgressDownloads.kt
@@ -14,11 +14,13 @@ class GetInProgressDownloads @Inject constructor(
     private val getMovies: GetMovies
 ) {
     operator fun invoke(): Flow<List<InProgressDownload>> {
-        return downloadManager.downloadJobs
+        return downloadManager.downloadStatuses
             .combine(flow { emit(getMovies()) }) { jobs, movies ->
-                jobs.values.mapNotNull { downloadStatus ->
-                    movies.find { it.id == downloadStatus.id }?.let { movie ->
-                        InProgressDownload(downloadStatus.id, movie.title, downloadStatus.percent)
+                arrayListOf<InProgressDownload>().also { list ->
+                    for ((id, percentage) in jobs) {
+                        movies.find { it.id == id }?.let { movie ->
+                            list.add(InProgressDownload(id, movie.title, percentage))
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/DownloadListActivity.kt
+++ b/app/src/main/java/io/mercury/coroutinesandbox/view/downloader/DownloadListActivity.kt
@@ -20,11 +20,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import io.mercury.coroutinesandbox.interactors.CancelMovieDownload
 import io.mercury.coroutinesandbox.interactors.DownloadMovie
 import io.mercury.coroutinesandbox.view.component.DownloadIndicatorFactory
 import io.mercury.coroutinesandbox.view.downloader.DownloadListFeature.State
@@ -43,6 +45,9 @@ class DownloadListActivity : ComponentActivity() {
 
     @Inject
     lateinit var downloadMovie: DownloadMovie
+
+    @Inject
+    lateinit var cancelMovieDownload: CancelMovieDownload
 
     @Inject
     lateinit var downloadIndicatorFactory: DownloadIndicatorFactory
@@ -88,6 +93,11 @@ class DownloadListActivity : ComponentActivity() {
                                     items(state.inProgressDownloads) { download ->
                                         Box(modifier = Modifier.fillMaxWidth()) {
                                             Text(download.title)
+
+                                            Button(onClick = { cancelMovieDownload(download.id) }, modifier = Modifier.align(
+                                                Alignment.Center)) {
+                                                Text("Cancel")
+                                            }
                                             downloadIndicatorFactory.DownloadIndicator(
                                                 id = download.id,
                                                 Modifier.align(Alignment.TopEnd)
@@ -132,10 +142,8 @@ class DownloadListActivity : ComponentActivity() {
     }
 
     private fun downloadSomething() {
-        MainScope().launch {
-            if (!downloadables.empty()) {
-                downloadMovie(downloadables.pop())
-            }
+        if (!downloadables.empty()) {
+            downloadMovie(downloadables.pop())
         }
     }
 }


### PR DESCRIPTION
The MovieDownloadManager now handles all the concurrency via injected scope and dispatcher. The Manager and it's operations live beyond the callers to the download/cancel methods so it made sense to have those be non-suspending functions, especially since those are fire-and-forget.